### PR TITLE
Update Home Assistant 2025.6

### DIFF
--- a/custom_components/kocom_energy/__init__.py
+++ b/custom_components/kocom_energy/__init__.py
@@ -13,9 +13,10 @@ async def async_setup_entry(hass, entry):
     hass.data[DOMAIN][entry.entry_id] = entry.data
 
     # 센서 외 다른 플랫폼을 사용할 경우를 위해 작업
-    for platform in PLATFORMS:
-        hass.async_create_task(hass.config_entries.async_forward_entry_setup(entry, platform))
-
+    await hass.async_create_task(
+        hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    )
+    
     return True
 
 # async def async_unload_entry(hass, entry):


### PR DESCRIPTION
Detected that custom integration 'kocom_energy' calls async_forward_entry_setup for integration, which is deprecated, await async_forward_entry_setups instead at custom_components/kocom_energy/__init__.py, line 17: hass.async_create_task(hass.config_entries.async_forward_entry_setup(entry, platform)). This will stop working in Home Assistant 2025.6, please report it to the author of the 'kocom_energy' custom integration